### PR TITLE
ci: Remove swift 5.8 and 5.9 builds from test matrix. Add Swift 6.1.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,12 +36,12 @@ jobs:
     strategy:
       matrix:
         swift-image:
-          - "swift:5.8-jammy"
-          - "swift:5.9-jammy"
           - "swift:5.10-jammy"
           - "swift:5.10-noble"
           - "swift:6.0-jammy"
           - "swift:6.0-noble"
+          - "swift:6.1-jammy"
+          - "swift:6.1-noble"
     runs-on: ubuntu-latest
     container: ${{ matrix.swift-image }}
     steps:


### PR DESCRIPTION
The current tip of main for swift-nio requires Swift 5.10. A number of repositories consuming this build matrix likely build swift-nio, and will become broken when consuming the latest version of [swift-nio](https://github.com/apple/swift-nio/blob/main/Package.swift#L1).

This removes versions of Swift older than 5.10 from the test matrix, and adds Swift 6.1.