### PR TITLE
Adds Swift 6.2 testing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,12 +36,12 @@ jobs:
     strategy:
       matrix:
         swift-image:
-          - "swift:5.10-jammy"
-          - "swift:5.10-noble"
           - "swift:6.0-jammy"
           - "swift:6.0-noble"
           - "swift:6.1-jammy"
           - "swift:6.1-noble"
+          - "swift:6.2-jammy"
+          - "swift:6.2-noble"
     runs-on: ubuntu-latest
     container: ${{ matrix.swift-image }}
     steps:


### PR DESCRIPTION
As per our 3-version compatibility guarantees, Swift 5.10 testing was dropped