### PR TITLE
Converts to swift-format

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,19 +6,20 @@ on:
       package_path:
         type: string
         required: false
-        default: ''
+        default: './'
         description: "Specifies a subpath of the checkout that the package is contained in."
 
 jobs:
   format:
     name: Format linting
     runs-on: ubuntu-latest
+    container: swift:latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Pull formatting docker image
-        run: docker pull ghcr.io/nicklockwood/swiftformat:latest
-      - name: Run format linting
-        run: docker run --rm -v ${{ github.workspace }}:/repo ghcr.io/nicklockwood/swiftformat:latest /repo/${{ inputs.package_path }} --lint
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Format
+      run: |
+        swift format lint \
+          --parallel \
+          --recursive \
+          ${{ inputs.package_path != './' && inputs.package_path || './' }}

--- a/WorkflowTestPackage/.swift-format
+++ b/WorkflowTestPackage/.swift-format
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "indentation" : {
+    "spaces" : 4
+  },
+  "lineBreakBeforeEachArgument": true
+}

--- a/WorkflowTestPackage/Package.swift
+++ b/WorkflowTestPackage/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(
             name: "WorkflowTestPackage",
             targets: ["WorkflowTestPackage"]
-        ),
+        )
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/WorkflowTestPackage/Tests/WorkflowTestPackageTests/WorkflowTestPackageTests.swift
+++ b/WorkflowTestPackage/Tests/WorkflowTestPackageTests/WorkflowTestPackageTests.swift
@@ -1,5 +1,6 @@
-@testable import WorkflowTestPackage
 import XCTest
+
+@testable import WorkflowTestPackage
 
 class WorkflowTestPackageTests: XCTestCase {
     func testHello() {


### PR DESCRIPTION
This changes from using https://github.com/nicklockwood/SwiftFormat to https://github.com/swiftlang/swift-format as the primary backend. `swift-format` is the now standard formatter built into the language CLI itself, so it's easier for contributors to use.